### PR TITLE
Trebuchet: fix derp

### DIFF
--- a/src/com/android/launcher3/Launcher.java
+++ b/src/com/android/launcher3/Launcher.java
@@ -3097,11 +3097,7 @@ public class Launcher extends BaseActivity
     public void tryAndUpdatePredictedApps() {
         List<ComponentKeyMapper<AppInfo>> apps = null;
         if (mSharedPrefs.getBoolean("pref_predictive_apps", true)) {
-            if (mLauncherCallbacks == null) {
-                apps = mPredictiveAppsProvider.getPredictions();
-            } else {
-                apps = mLauncherCallbacks.getPredictedApps();
-            }
+            apps = mPredictiveAppsProvider.getPredictions();
         }
 
         if (apps != null) {


### PR DESCRIPTION
 * a77601a96c9dc0f7489e87a6ab0bb2499b8a9461 made
  it load predictive apps through the SearchLauncherCallback
  instead of our implementation

Change-Id: I939adb6e0c4009cd22df4f81eb0ce5ecb30134ad