### PR TITLE
Lint fix: Invalid vector path in horizontal_ellipsis

### DIFF
--- a/res/drawable/horizontal_ellipsis.xml
+++ b/res/drawable/horizontal_ellipsis.xml
@@ -22,6 +22,6 @@
         android:tint="?android:attr/textColorSecondary" >
 
     <path
-        android:pathData="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+        android:pathData="M6 10c-1.1 0-2 0.9-2 2s0.9 2 2 2 2-0.9 2-2-0.9-2-2-2zm12 0c-1.1 0-2 0.9-2 2s0.9 2 2 2 2-0.9 2-2-0.9-2-2-2zm-6 0c-1.1 0-2 0.9-2 2s0.9 2 2 2 2-0.9 2-2-0.9-2-2-2z"
         android:fillColor="@android:color/white" />
 </vector>


### PR DESCRIPTION
Use 0.9 instead of .9 in the vector drawable path to
avoid crashes on some devices.

Test: Manual
Change-Id: I9d5889fdf48fbb2f09995b75d4f20c47454ef591