### PR TITLE
Trebuchet: Disallow status bar swipe on widgets sheet

### DIFF
--- a/src/com/android/launcher3/widget/WidgetsFullSheet.java
+++ b/src/com/android/launcher3/widget/WidgetsFullSheet.java
@@ -196,7 +196,8 @@ public class WidgetsFullSheet extends BaseWidgetSheet
 
     @Override
     protected boolean isOfType(int type) {
-        return (type & TYPE_WIDGETS_FULL_SHEET) != 0;
+        return (type & TYPE_WIDGETS_FULL_SHEET) != 0 ||
+                (type & TYPE_STATUS_BAR_SWIPE_DOWN_DISALLOW) != 0;
     }
 
     @Override


### PR DESCRIPTION
* Fixes: https://gitlab.com/LineageOS/issues/android/issues/372.

* Status bar swipe feature interferes with scrolling there are enough widgets to scroll
  through. If there aren't enough widgets to scroll through, the swipe down will close
  the widgets sheet, so there is no use for this feature here.

Change-Id: Icecf1f0f8d093a2f5c61d1a0ce7975cbc98cf2a2