### PR TITLE
Revert "config: enable LAUNCHER3_PROMISE_APPS_IN_ALL_APPS"

### DIFF
--- a/src/com/android/launcher3/config/BaseFlags.java
+++ b/src/com/android/launcher3/config/BaseFlags.java
@@ -61,7 +61,7 @@ public abstract class BaseFlags {
     public static final boolean IS_DOGFOOD_BUILD = false;
 
     // When enabled the promise icon is visible in all apps while installation an app.
-    public static final boolean LAUNCHER3_PROMISE_APPS_IN_ALL_APPS = true;
+    public static final boolean LAUNCHER3_PROMISE_APPS_IN_ALL_APPS = false;
 
     // When enabled a promise icon is added to the home screen when install session is active.
     public static final TogglableFlag PROMISE_APPS_NEW_INSTALLS =


### PR DESCRIPTION
For some reason, the promise icon doesn't get cleared after the
app is installed in 10.

This reverts commit 4286514ebfb64578864141eaaa4d8e4ff85fe9a7.

Change-Id: I202448d09a2306cf3c902c3cd50909cd9b3bc219